### PR TITLE
Adding update and remove methods to LazoIndex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id 'eclipse'
 }
 
-version = '0.1.0'
+version = '0.1.1'
 
 dependencies {
     implementation 'com.google.guava:guava:23.0'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id 'eclipse'
 }
 
-version = '0.1.1'
+version = '0.1.0'
 
 dependencies {
     implementation 'com.google.guava:guava:23.0'

--- a/src/main/java/lazo/index/LazoIndex.java
+++ b/src/main/java/lazo/index/LazoIndex.java
@@ -184,35 +184,35 @@ public class LazoIndex {
     }
 
     public boolean insert(Object key, LazoSketch sketch) {
-    	// Store cardinality of key
-    	keyCardinality.put(key, sketch.getCardinality());
-    	// Obtain segments of this sketch
-    	List<long[]> segments = new ArrayList<>();
-    	for (int start : this.hashRanges) {
-    	    int end = start + this.gcdSliceSize;
-    	    long[] segment = Arrays.copyOfRange(sketch.getHashValues(), start, end);
-    	    segments.add(segment);
-    	}
-    	// Insert key in the hashmap handling each band
-    	for (int i = 0; i < this.gcdBands; i++) {
-    	    long[] sg = segments.get(i);
-    	    Map<Long, Set<Object>> hashTable = hashTables.get(i);
-    	    long segId = segmentHash(sg);
-    	    if (hashTable.get(segId) == null) {
-        		Set<Object> l = new HashSet<>();
-        		hashTable.put(segId, l);
-    	    }
-    	    hashTable.get(segId).add(key);
-    	    
-    	    // Storing segment information
-    	    Map<Object, Set<Long>> segmentIdInfo = segmentIds.get(i);
-    	    if (segmentIdInfo.get(key) == null) {
-    	        Set<Long> l = new HashSet<>();
-    	        segmentIdInfo.put(key, l);
-    	    }
-    	    segmentIdInfo.get(key).add(segId);
-    	}
-    	return true;
+	// Store cardinality of key
+	keyCardinality.put(key, sketch.getCardinality());
+	// Obtain segments of this sketch
+	List<long[]> segments = new ArrayList<>();
+	for (int start : this.hashRanges) {
+	    int end = start + this.gcdSliceSize;
+	    long[] segment = Arrays.copyOfRange(sketch.getHashValues(), start, end);
+	    segments.add(segment);
+	}
+	// Insert key in the hashmap handling each band
+	for (int i = 0; i < this.gcdBands; i++) {
+	    long[] sg = segments.get(i);
+	    Map<Long, Set<Object>> hashTable = hashTables.get(i);
+	    long segId = segmentHash(sg);
+	    if (hashTable.get(segId) == null) {
+		Set<Object> l = new HashSet<>();
+		hashTable.put(segId, l);
+	    }
+	    hashTable.get(segId).add(key);
+
+	    // Storing segment information
+	    Map<Object, Set<Long>> segmentIdInfo = segmentIds.get(i);
+	    if (segmentIdInfo.get(key) == null) {
+	        Set<Long> l = new HashSet<>();
+	        segmentIdInfo.put(key, l);
+	    }
+	    segmentIdInfo.get(key).add(segId);
+	}
+	return true;
     }
     
     public boolean remove(Object key) {

--- a/src/main/java/lazo/index/LazoIndex.java
+++ b/src/main/java/lazo/index/LazoIndex.java
@@ -215,6 +215,11 @@ public class LazoIndex {
 	return true;
     }
     
+    // To remove existing data from the index, the segments are saved
+    //   when inserting data. There is a tradeoff between the default
+    //   storage needed to keep the segments vs. keeping just the hash
+    //   values (reduce data structure burden) and do more work on removal.
+    //   Depending on workloads one or the other would be better.
     public boolean remove(Object key) {
         if (keyCardinality.get(key) == null) {
             return false;

--- a/src/main/java/lazo/sketch/LazoSketch.java
+++ b/src/main/java/lazo/sketch/LazoSketch.java
@@ -139,4 +139,8 @@ public class LazoSketch implements Sketch {
 	return merged;
     }
 
+    public void setCardinality(long cardinality) {
+        this.cardinality = cardinality;
+    }
+
 }

--- a/src/test/java/lazo/index/LazoIndexTest.java
+++ b/src/test/java/lazo/index/LazoIndexTest.java
@@ -12,15 +12,15 @@ public class LazoIndexTest {
 
     @Test
     public void testGCD() {
-    	LazoIndex li = new LazoIndex(64);
-    
-    	Integer numbers[] = new Integer[] { 2, 4, 6, 8, 12, 24, 46, 64, 66, 88 };
-    	int gcd = li.findGCDOf(numbers);
-    	assertTrue(gcd == 2);
-    
-    	numbers = new Integer[] { 3, 6, 9, 12, 15, 18, 21, 24, 27, 30 };
-    	gcd = li.findGCDOf(numbers);
-    	assertTrue(gcd == 3);
+	LazoIndex li = new LazoIndex(64);
+
+	Integer numbers[] = new Integer[] { 2, 4, 6, 8, 12, 24, 46, 64, 66, 88 };
+	int gcd = li.findGCDOf(numbers);
+	assertTrue(gcd == 2);
+
+	numbers = new Integer[] { 3, 6, 9, 12, 15, 18, 21, 24, 27, 30 };
+	gcd = li.findGCDOf(numbers);
+	assertTrue(gcd == 3);
     }
     
     @Test

--- a/src/test/java/lazo/index/LazoIndexTest.java
+++ b/src/test/java/lazo/index/LazoIndexTest.java
@@ -2,21 +2,77 @@ package lazo.index;
 
 import static org.junit.Assert.assertTrue;
 
+import java.util.Set;
+
 import org.junit.Test;
+
+import lazo.sketch.LazoSketch;
 
 public class LazoIndexTest {
 
     @Test
     public void testGCD() {
-	LazoIndex li = new LazoIndex(64);
-
-	Integer numbers[] = new Integer[] { 2, 4, 6, 8, 12, 24, 46, 64, 66, 88 };
-	int gcd = li.findGCDOf(numbers);
-	assertTrue(gcd == 2);
-
-	numbers = new Integer[] { 3, 6, 9, 12, 15, 18, 21, 24, 27, 30 };
-	gcd = li.findGCDOf(numbers);
-	assertTrue(gcd == 3);
+    	LazoIndex li = new LazoIndex(64);
+    
+    	Integer numbers[] = new Integer[] { 2, 4, 6, 8, 12, 24, 46, 64, 66, 88 };
+    	int gcd = li.findGCDOf(numbers);
+    	assertTrue(gcd == 2);
+    
+    	numbers = new Integer[] { 3, 6, 9, 12, 15, 18, 21, 24, 27, 30 };
+    	gcd = li.findGCDOf(numbers);
+    	assertTrue(gcd == 3);
+    }
+    
+    @Test
+    public void testUpdate() {
+        LazoIndex li = new LazoIndex(64);
+        
+        // Adding values 0 to 10 to index
+        LazoSketch indexSketch = new LazoSketch(64);
+        for (int i = 0; i < 11; i++) {
+            indexSketch.update(new Integer(i).toString());
+        }
+        li.insert("test", indexSketch);
+        
+        // Querying values 11 to 20
+        LazoSketch querySketch = new LazoSketch(64);
+        for (int i = 11; i < 21; i++) {
+            querySketch.update(new Integer(i).toString());
+        }
+        Set<LazoIndex.LazoCandidate> candidates =
+                li.queryContainment(querySketch, 0.0f);
+        assertTrue(candidates.size() == 0);
+        
+        // Querying values 0 to 10
+        querySketch = new LazoSketch(64);
+        for (int i = 0; i < 11; i++) {
+            querySketch.update(new Integer(i).toString());
+        }
+        candidates = li.queryContainment(querySketch, 0.0f);
+        assertTrue(candidates.size() == 1);
+        
+        // Updating 'test' to only have values 11 to 20
+        indexSketch = new LazoSketch(64);
+        for (int i = 11; i < 21; i++) {
+            indexSketch.update(new Integer(i).toString());
+        }
+        li.update("test", indexSketch);
+        
+        // Querying values 11 to 20
+        querySketch = new LazoSketch(64);
+        for (int i = 11; i < 21; i++) {
+            querySketch.update(new Integer(i).toString());
+        }
+        candidates = li.queryContainment(querySketch, 0.0f);
+        assertTrue(candidates.size() == 1);
+        
+        // Querying values 0 to 10
+        querySketch = new LazoSketch(64);
+        for (int i = 0; i < 11; i++) {
+            querySketch.update(new Integer(i).toString());
+        }
+        candidates = li.queryContainment(querySketch, 0.0f);
+        assertTrue(candidates.size() == 0);
     }
 
     // TODO:


### PR DESCRIPTION
This pull requests adds a `remove` and an `update` method to `LazoIndex` (an update, in this case, is a removal followed by a new insertion). In addition, it also adds a method to set the cardinality in a `LazoSketch`, which is useful to load existing sketch information saved in some store.

This will be particularly useful for [Lazo Index Service](https://gitlab.com/ViDA-NYU/datamart/lazo-index-service), a service we have been developing to index textual/categorical data using Lazo.