### PR TITLE
fix a problem in querySlice and prime number generation

### DIFF
--- a/src/main/java/lazo/benchmark/IndexBenchmark.java
+++ b/src/main/java/lazo/benchmark/IndexBenchmark.java
@@ -12,7 +12,7 @@ import lazo.sketch.SketchType;
 
 public class IndexBenchmark {
 
-    private static long mersennePrime = (1 << 61) - 1;
+    private static long mersennePrime = ((long) 1 << 61) - 1;
     private static Random gen = new Random(111);
 
     public static List<LazoSketch> getSketches(int number, int k) {

--- a/src/main/java/lazo/index/LazoIndex.java
+++ b/src/main/java/lazo/index/LazoIndex.java
@@ -300,7 +300,7 @@ public class LazoIndex {
 		long[] segment = Arrays.copyOfRange(sketch.getHashValues(), start, end);
 		long segId = segmentHash(segment);
 
-		Map<Long, Set<Object>> hashTable = this.hashTables.get(i);
+		Map<Long, Set<Object>> hashTable = this.hashTables.get(b);
 		if (hashTable.containsKey(segId)) {
 		    Set<Object> queryResult = hashTable.get(segId);
 		    if (bandCandidates.size() == 0) {

--- a/src/main/java/lazo/sketch/MinHash.java
+++ b/src/main/java/lazo/sketch/MinHash.java
@@ -9,7 +9,7 @@ import com.google.common.hash.HashFunction;
 
 public class MinHash implements Sketch {
 
-    private final long mersennePrime = (1 << 61) - 1;
+    private final long mersennePrime = ((long) 1 << 61) - 1;
 
     private int seed;
     private int k;


### PR DESCRIPTION
1. The global hash table maintains the mapping from each band to its respective list of segments. Within these segments, an additional mapping links each segment to its corresponding list of candidates that hash to that particular segment.
Thus, Line 303 in LazoIndex.java should be fetching the b-th band. In the current implementation, when the number of rows within a band equals 1, line 303 will always fetch the first band, causing the recall to be low.
2. There is a small issue with the prime number used in the minHash function. Though `mersennePrime` is declared to be long, its value (1 << 61) - 1 still has the type Integer and will be equal to the upper limit of integer, which is much smaller than the correct value of (1 << 61) - 1. I fix this by manually casting it to the long type.